### PR TITLE
Data loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,29 +18,12 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-dependencies = [
-  "numpy",
-  "torch"
-]
+dependencies = ["numpy", "torch", "nibabel"]
 
 [project.optional-dependencies]
-test = [
-  "coverage",
-  "codecov",
-  "pre-commit"
-]
-lint = [
-  "mypy",
-  "flake8",
-  "isort",
-  "pre-commit",
-  "autopep8",
-  "pydocstyle"
-]
-docs = [
-  "sphinx",
-  "sphinx_rtd_theme",
-]
+test = ["coverage", "codecov", "pre-commit"]
+lint = ["mypy", "flake8", "isort", "pre-commit", "autopep8", "pydocstyle"]
+docs = ["sphinx", "sphinx_rtd_theme"]
 
 [project.urls]
 "repository" = "https://github.com/ckolbPTB/InhomCorr"

--- a/src/inhomcorr/bias/torchio_bias.py
+++ b/src/inhomcorr/bias/torchio_bias.py
@@ -47,7 +47,7 @@ class BiasCreatorTorchio(BiasCreator):
 
     def get_random_bias_fields(self, image: ImageData,
                                number: int) -> list[ImageData]:
-        """Inferface of a bias field creator provding multiple bias fields.
+        """Inferface of a bias field creator providing multiple bias fields.
 
         Parameters
         ----------

--- a/src/inhomcorr/data_loader/data_loader_interface.py
+++ b/src/inhomcorr/data_loader/data_loader_interface.py
@@ -1,0 +1,38 @@
+"""Interface for Data loader."""
+from abc import ABC
+from abc import abstractmethod
+
+from inhomcorr.interfaces import QMRIData
+
+
+class QMRIDataLoader(ABC):
+    """Data loader for QMRI datasets."""
+
+    @abstractmethod
+    def __init__(self) -> None:
+        pass
+
+    @abstractmethod
+    def get_data(self, index: int) -> QMRIData:
+        """Return single QMRIData object.
+
+        Parameters
+        ----------
+        index
+            Index of the object
+
+        Returns
+        -------
+            QMRIData object
+        """
+        pass
+
+    @abstractmethod
+    def get_all_data(self) -> list[QMRIData]:
+        """Return all available QMRIData objects.
+
+        Returns
+        -------
+            List of QMRIData objects
+        """
+        pass

--- a/src/inhomcorr/data_loader/data_loader_nii.py
+++ b/src/inhomcorr/data_loader/data_loader_nii.py
@@ -1,0 +1,104 @@
+"""Data loader for QMRIData objects from nifti files."""
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import torch
+
+from inhomcorr.data_loader.data_loader_interface import QMRIDataLoader
+from inhomcorr.interfaces import QMRIData
+
+
+class QMRIDataLoaderNii(QMRIDataLoader):
+    """Load QMRIData objects from nifti file(s)."""
+
+    def __init__(self) -> None:
+        self.qmri_data_list: list[QMRIData] = []
+
+    def add_qmridata_from_folder(self, foldername_nii: str) -> None:
+        """Read in all nii files from folder and add them.
+
+        Parameters
+        ----------
+            foldername_nii (str): Foldername where all nii files are
+        """
+        # Verify path
+        path_nii = Path(foldername_nii)
+        assert path_nii.is_dir(), f'Directory {str(path_nii)} not found.'
+
+        # Get all nifti files
+        nii_file_list = path_nii.glob('*.nii')
+
+        # Create QMRIData
+        for nii_file in nii_file_list:
+            self.qmri_data_list.append(
+                self.load_data_from_single_file(str(nii_file)))
+
+    def load_data_from_single_file(self, filename_nii: str) -> QMRIData:
+        """Load quantitative paramaters from file and create a QMRIData object.
+
+        Parameters
+        ----------
+            Name of nifti file were parameters are stored
+
+        Returns
+        -------
+            QMRIData object containting t1, rho and nifti header
+        """
+        # Create empty QMRIData object
+        qmri_data = QMRIData()
+
+        # Read in nii file
+        nii_file = nib.load(filename_nii)
+
+        # Get numpy data as float32
+        nii_data = np.asarray(nii_file.dataobj, dtype=np.float32)
+
+        # Verify size
+        if nii_data.ndim != 4:
+            raise NotImplementedError(
+                'Currently only 4-dimensional nifti images can be read in')
+
+        # Add t1
+        qmri_data.t1 = torch.FloatTensor(nii_data[:, :, :, 2])
+
+        # Nifti is [x,y,z], QMRIData is [z,y,x]
+        qmri_data.t1 = torch.moveaxis(qmri_data.t1, (0, 1, 2), (2, 1, 0))
+
+        # Calculate rho from m0
+        rho = nii_data[:, :, :, 0]
+
+        # Add rho
+        qmri_data.rho = torch.FloatTensor(rho)
+
+        # Nifti is [x,y,z], QMRIData is [z,y,x]
+        qmri_data.rho = torch.moveaxis(qmri_data.rho, (0, 1, 2), (2, 1, 0))
+
+        # Add nifti header
+        qmri_data.header = dict(nii_file.header)
+
+        return (qmri_data)
+
+    def get_data(self, index: int) -> QMRIData:
+        """Return single QMRIData object.
+
+        Parameters
+        ----------
+        index
+            Index of the object
+
+        Returns
+        -------
+            QMRIData object
+        """
+        assert index < len(self.qmri_data_list)
+        return (self.qmri_data_list[index])
+
+    def get_all_data(self) -> list[QMRIData]:
+        """Return all available QMRIData objects.
+
+        Returns
+        -------
+            List of QMRIData objects
+        """
+        return (self.qmri_data_list)

--- a/src/inhomcorr/data_loader/data_loader_nii.py
+++ b/src/inhomcorr/data_loader/data_loader_nii.py
@@ -67,7 +67,6 @@ class QMRIDataLoaderNii(QMRIDataLoader):
         qmri_data.t1 = torch.moveaxis(qmri_data.t1, (0, 1, 2), (2, 1, 0))
 
         # Calculate rho from m0
-        # Get m0
         m0 = nii_data[:, :, :, 0]
 
         # Calculate mask
@@ -76,7 +75,7 @@ class QMRIDataLoaderNii(QMRIDataLoader):
         rho[m0 > 0.02] = 1
 
         rho = ndi.morphology.binary_opening(
-            rho.astype(int), np.ones((2, 2)).astype(int), iterations=10)
+            rho.astype(int), np.ones((2, 2, 2)).astype(int), iterations=10)
 
         # Add rho
         qmri_data.rho = torch.FloatTensor(rho)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,43 @@
+"""Data loader tests."""
+import os
+import unittest
+
+import nibabel as nib
+import numpy as np
+
+from inhomcorr.data_loader.data_loader_nii import QMRIDataLoaderNii
+from inhomcorr.interfaces import QMRIData
+
+
+class TestQMRIDataLoaderNii(unittest.TestCase):
+
+    def setUp(self):
+        # Get working dir
+        self.tmp_path = os.getcwd()
+
+        # Create nifti image containing t1 and rho and save as file
+        self.shape = (20, 30, 1, 3)
+        dat = np.random.randn(self.shape[0], self.shape[1],
+                              self.shape[2], self.shape[3])
+        nifti_im = nib.Nifti1Image(dat, affine=np.eye(4))
+        nifti_im.header['descrip'] = 'testing'
+        self.nii_file = self.tmp_path + '/test_nii_rho_alpha_t1.nii'
+        nib.save(nifti_im, self.nii_file)
+
+    def tearDown(self):
+        # Delete file
+        os.remove(self.nii_file)
+
+    def test_load_qmri_nii_file(self):
+        qmri_dat_ld = QMRIDataLoaderNii()
+        self.assertEqual(len(qmri_dat_ld.qmri_data_list), 0)
+        qmri_dat_ld.add_qmridata_from_folder(self.tmp_path)
+
+        # Verify that the data was added correctly
+        self.assertEqual(len(qmri_dat_ld.qmri_data_list), 1)
+        self.assertEqual(len(qmri_dat_ld.get_all_data()), 1)
+
+        # Verfiy type, shape and header of data
+        qmri_dat = qmri_dat_ld.get_data(0)
+        self.assertIsInstance(qmri_dat, QMRIData)
+        self.assertEqual(list(qmri_dat.t1.shape), list(self.shape[-2::-1]))


### PR DESCRIPTION
Basic implementation to load the nifti data into QMRIData objects. The class then provides an interface to get a single QMRIData object or a list of all available ones.

MISSING: Currently M0 is used as rho here: https://github.com/ckolbPTB/InhomCorr/blob/7f1b4a7a1600cfe3c66bf474d2abdfcc0e2bdf13/src/inhomcorr/data_loader/data_loader_nii.py#L69 

@CGatefait and @hkimon were working on a method to calculate a constant rho from m0. this needs to be added here.